### PR TITLE
Revert rom address mirroring, fix async clk in PPU (#472)

### DIFF
--- a/SNES.sv
+++ b/SNES.sv
@@ -865,52 +865,6 @@ always @(posedge clk_mem) begin
 	sdram_download_en <= sdram_download;
 end
 
-// Rom address mirroring when rom size is not a power of 2 (SNESdev wiki)
-reg  [23:0] rom_mirror_split, rom_mirror_rmask, rom_file_sz;
-reg         rom_mirror_en;
-
-always @(posedge clk_sys) begin
-	if (~old_downloading & cart_download) begin
-		rom_mirror_en <= 1'b0;
-	end
-
-	if (cart_download & ioctl_wr) begin
-		if (ioctl_addr == 8)  rom_file_sz[15:0]  <= ioctl_dout;
-		if (ioctl_addr == 10) rom_file_sz[23:16] <= ioctl_dout[7:0];
-	end
-
-	if (old_downloading & ~cart_download) begin
-		if (|(rom_file_sz & (rom_file_sz - 24'd1))) begin
-			rom_mirror_en <= 1'b1;
-			if (rom_file_sz[23]) begin
-				rom_mirror_split <= 24'h800000;
-				rom_mirror_rmask <= rom_file_sz - 24'h800001;
-			end else if (rom_file_sz[22]) begin
-				rom_mirror_split <= 24'h400000;
-				rom_mirror_rmask <= rom_file_sz - 24'h400001;
-			end else if (rom_file_sz[21]) begin
-				rom_mirror_split <= 24'h200000;
-				rom_mirror_rmask <= rom_file_sz - 24'h200001;
-			end else if (rom_file_sz[20]) begin
-				rom_mirror_split <= 24'h100000;
-				rom_mirror_rmask <= rom_file_sz - 24'h100001;
-			end else if (rom_file_sz[19]) begin
-				rom_mirror_split <= 24'h080000;
-				rom_mirror_rmask <= rom_file_sz - 24'h080001;
-			end else begin
-				rom_mirror_split <= 24'h040000;
-				rom_mirror_rmask <= rom_file_sz - 24'h040001;
-			end
-		end
-	end
-end
-
-wire        rom_in_range  = !(|(ROM_ADDR & ~rom_mask));
-wire        rom_in_mirror = rom_mirror_en & rom_in_range & |(ROM_ADDR & rom_mirror_split);
-wire [23:0] rom_addr_out  = rom_in_mirror
-             ? (rom_mirror_split | (ROM_ADDR & rom_mirror_rmask))
-             : ROM_ADDR;
-
 reg READ_PULSE;
 always @(posedge clk_sys)
 	READ_PULSE <= SNES_SYSCLKR_CE;
@@ -933,7 +887,7 @@ sdram sdram
 	.init(0), //~clock_locked),
 	.clk(clk_mem),
 	
-	.addr0(sdram_download_en ? sdram_download_addr : rom_addr_out),
+	.addr0(sdram_download_en ? sdram_download_addr : ROM_ADDR),
 	.din0(sdram_download_en ? sdram_download_data : ROM_D),
 	.dout0(ROM_Q),
 	.rd0(sdram_download_en ? 1'b0 : !RESET_N ? RESET_REFRESH : ~ROM_OE_N),

--- a/rtl/PPU.vhd
+++ b/rtl/PPU.vhd
@@ -783,10 +783,10 @@ VRAM_READ <= '1' when NO_BLANK = '1' else
 
 VRAM_ADDRA <= VMADD_TRANS when NO_BLANK = '0' else 
               BG_VRAM_ADDRA when BG_FETCH = '1' else 
-				  OBJ_VRAM_ADDR when OBJ_FETCH = '1';
+				  OBJ_VRAM_ADDR;
 VRAM_ADDRB <= VMADD_TRANS when NO_BLANK = '0' else 
               BG_VRAM_ADDRB when BG_FETCH = '1' else 
-				  OBJ_VRAM_ADDR when OBJ_FETCH = '1';			 
+				  OBJ_VRAM_ADDR;
 				 
 
 VRAM_DAO <= DI;


### PR DESCRIPTION
* Revert "Fix save states when rom address mirror is active (#470)"

This reverts commit f9901ee8e73c266239853da0b4f09c720503f32d.

* Revert "Add rom address mirroring when rom size is not a power of 2 (#469)"

This reverts commit 38396226dd0701d0220bf127c6d17b6feab1c35c.

* PPU: fix FORCE_BLANK inferred as async clk